### PR TITLE
No combos can be in string format

### DIFF
--- a/crates/revi-core/src/commands.rs
+++ b/crates/revi-core/src/commands.rs
@@ -25,14 +25,6 @@ impl PartialEq for BoxedCommand {
 
 #[derive(Debug, PartialEq)]
 pub struct CursorUp;
-impl CursorUp {
-    pub fn new_box() -> BoxedCommand {
-        BoxedCommand {
-            command: Box::new(CursorUp),
-        }
-    }
-}
-
 impl Command for CursorUp {
     fn call(&self, revi: &mut ReVi, count: usize) {
         revi.focused_window_mut().move_cursor_up(count);
@@ -45,14 +37,6 @@ impl Command for CursorUp {
 
 #[derive(Debug, PartialEq)]
 pub struct CursorDown;
-impl CursorDown {
-    pub fn new_box() -> BoxedCommand {
-        BoxedCommand {
-            command: Box::new(CursorDown),
-        }
-    }
-}
-
 impl Command for CursorDown {
     fn call(&self, revi: &mut ReVi, count: usize) {
         revi.focused_window_mut().move_cursor_down(count);
@@ -65,14 +49,6 @@ impl Command for CursorDown {
 
 #[derive(Debug, PartialEq)]
 pub struct CursorLeft;
-impl CursorLeft {
-    pub fn new_box() -> BoxedCommand {
-        BoxedCommand {
-            command: Box::new(CursorLeft),
-        }
-    }
-}
-
 impl Command for CursorLeft {
     fn call(&self, revi: &mut ReVi, count: usize) {
         revi.focused_window_mut().move_cursor_left(count);
@@ -85,14 +61,6 @@ impl Command for CursorLeft {
 
 #[derive(Debug, PartialEq)]
 pub struct CursorRight;
-impl CursorRight {
-    pub fn new_box() -> BoxedCommand {
-        BoxedCommand {
-            command: Box::new(CursorRight),
-        }
-    }
-}
-
 impl Command for CursorRight {
     fn call(&self, revi: &mut ReVi, count: usize) {
         revi.focused_window_mut().move_cursor_right(count);
@@ -105,14 +73,6 @@ impl Command for CursorRight {
 
 #[derive(Debug, PartialEq)]
 pub struct ScrollUp;
-impl ScrollUp {
-    pub fn new_box() -> BoxedCommand {
-        BoxedCommand {
-            command: Box::new(ScrollUp),
-        }
-    }
-}
-
 impl Command for ScrollUp {
     fn call(&self, revi: &mut ReVi, count: usize) {
         revi.focused_window_mut().scroll_up(count);
@@ -125,14 +85,6 @@ impl Command for ScrollUp {
 
 #[derive(Debug, PartialEq)]
 pub struct ScrollDown;
-impl ScrollDown {
-    pub fn new_box() -> BoxedCommand {
-        BoxedCommand {
-            command: Box::new(ScrollDown),
-        }
-    }
-}
-
 impl Command for ScrollDown {
     fn call(&self, revi: &mut ReVi, count: usize) {
         revi.focused_window_mut().scroll_down(count);
@@ -145,14 +97,6 @@ impl Command for ScrollDown {
 
 #[derive(Debug, PartialEq)]
 pub struct Home;
-impl Home {
-    pub fn new_box() -> BoxedCommand {
-        BoxedCommand {
-            command: Box::new(Home),
-        }
-    }
-}
-
 impl Command for Home {
     fn call(&self, revi: &mut ReVi, _: usize) {
         revi.focused_window_mut().home();
@@ -165,14 +109,6 @@ impl Command for Home {
 
 #[derive(Debug, PartialEq)]
 pub struct End;
-impl End {
-    pub fn new_box() -> BoxedCommand {
-        BoxedCommand {
-            command: Box::new(End),
-        }
-    }
-}
-
 impl Command for End {
     fn call(&self, revi: &mut ReVi, _: usize) {
         revi.focused_window_mut().end();
@@ -184,14 +120,6 @@ impl Command for End {
 }
 #[derive(Debug, PartialEq)]
 pub struct MoveForwardByWord;
-impl MoveForwardByWord {
-    pub fn new_box() -> BoxedCommand {
-        BoxedCommand {
-            command: Box::new(MoveForwardByWord),
-        }
-    }
-}
-
 impl Command for MoveForwardByWord {
     fn call(&self, revi: &mut ReVi, _: usize) {
         revi.focused_window_mut().move_forward_by_word();
@@ -204,14 +132,6 @@ impl Command for MoveForwardByWord {
 
 #[derive(Debug, PartialEq)]
 pub struct MoveBackwardByWord;
-impl MoveBackwardByWord {
-    pub fn new_box() -> BoxedCommand {
-        BoxedCommand {
-            command: Box::new(MoveBackwardByWord),
-        }
-    }
-}
-
 impl Command for MoveBackwardByWord {
     fn call(&self, revi: &mut ReVi, _: usize) {
         revi.focused_window_mut().move_backward_by_word();
@@ -224,14 +144,6 @@ impl Command for MoveBackwardByWord {
 
 #[derive(Debug, PartialEq)]
 pub struct JumpToFirstLineBuffer;
-impl JumpToFirstLineBuffer {
-    pub fn new_box() -> BoxedCommand {
-        BoxedCommand {
-            command: Box::new(JumpToFirstLineBuffer),
-        }
-    }
-}
-
 impl Command for JumpToFirstLineBuffer {
     fn call(&self, revi: &mut ReVi, _: usize) {
         revi.focused_window_mut().jump_to_first_line_buffer();
@@ -244,14 +156,6 @@ impl Command for JumpToFirstLineBuffer {
 
 #[derive(Debug, PartialEq)]
 pub struct JumpToLastLineBuffer;
-impl JumpToLastLineBuffer {
-    pub fn new_box() -> BoxedCommand {
-        BoxedCommand {
-            command: Box::new(JumpToLastLineBuffer),
-        }
-    }
-}
-
 impl Command for JumpToLastLineBuffer {
     fn call(&self, revi: &mut ReVi, _: usize) {
         revi.focused_window_mut().jump_to_last_line_buffer();
@@ -264,14 +168,6 @@ impl Command for JumpToLastLineBuffer {
 
 #[derive(Debug, PartialEq)]
 pub struct Backspace;
-impl Backspace {
-    pub fn new_box() -> BoxedCommand {
-        BoxedCommand {
-            command: Box::new(Backspace),
-        }
-    }
-}
-
 impl Command for Backspace {
     fn call(&self, revi: &mut ReVi, _: usize) {
         revi.focused_window_mut().backspace();
@@ -284,14 +180,6 @@ impl Command for Backspace {
 
 #[derive(Debug, PartialEq)]
 pub struct NewLine;
-impl NewLine {
-    pub fn new_box() -> BoxedCommand {
-        BoxedCommand {
-            command: Box::new(NewLine),
-        }
-    }
-}
-
 impl Command for NewLine {
     fn call(&self, revi: &mut ReVi, _: usize) {
         if revi.focused != 0 {
@@ -306,14 +194,6 @@ impl Command for NewLine {
 
 #[derive(Debug, PartialEq)]
 pub struct FirstCharInLine;
-impl FirstCharInLine {
-    pub fn new_box() -> BoxedCommand {
-        BoxedCommand {
-            command: Box::new(FirstCharInLine),
-        }
-    }
-}
-
 impl Command for FirstCharInLine {
     fn call(&self, revi: &mut ReVi, _: usize) {
         revi.focused_window_mut().first_char_in_line();
@@ -326,14 +206,6 @@ impl Command for FirstCharInLine {
 
 #[derive(Debug, PartialEq)]
 pub struct DeleteChar;
-impl DeleteChar {
-    pub fn new_box() -> BoxedCommand {
-        BoxedCommand {
-            command: Box::new(DeleteChar),
-        }
-    }
-}
-
 impl Command for DeleteChar {
     fn call(&self, revi: &mut ReVi, _: usize) {
         revi.focused_window_mut().delete();
@@ -346,14 +218,6 @@ impl Command for DeleteChar {
 
 #[derive(Debug, PartialEq)]
 pub struct DeleteLine;
-impl DeleteLine {
-    pub fn new_box() -> BoxedCommand {
-        BoxedCommand {
-            command: Box::new(DeleteLine),
-        }
-    }
-}
-
 impl Command for DeleteLine {
     fn call(&self, revi: &mut ReVi, _: usize) {
         let line = revi.focused_window_mut().delete_line();
@@ -367,14 +231,6 @@ impl Command for DeleteLine {
 
 #[derive(Debug, PartialEq)]
 pub struct YankLine;
-impl YankLine {
-    pub fn new_box() -> BoxedCommand {
-        BoxedCommand {
-            command: Box::new(YankLine),
-        }
-    }
-}
-
 impl Command for YankLine {
     fn call(&self, revi: &mut ReVi, _: usize) {
         let yanked_line;
@@ -394,14 +250,6 @@ impl Command for YankLine {
 
 #[derive(Debug, PartialEq)]
 pub struct Paste;
-impl Paste {
-    pub fn new_box() -> BoxedCommand {
-        BoxedCommand {
-            command: Box::new(Paste),
-        }
-    }
-}
-
 impl Command for Paste {
     fn call(&self, revi: &mut ReVi, _: usize) {
         revi.queue.push(revi.focused);
@@ -422,14 +270,6 @@ impl Command for Paste {
 
 #[derive(Debug, PartialEq)]
 pub struct PasteBack;
-impl PasteBack {
-    pub fn new_box() -> BoxedCommand {
-        BoxedCommand {
-            command: Box::new(PasteBack),
-        }
-    }
-}
-
 impl Command for PasteBack {
     fn call(&self, revi: &mut ReVi, _: usize) {
         revi.queue.push(revi.focused);
@@ -450,14 +290,6 @@ impl Command for PasteBack {
 
 #[derive(Debug, PartialEq)]
 pub struct InsertChar(pub char);
-impl InsertChar {
-    pub fn new_box(c: char) -> BoxedCommand {
-        BoxedCommand {
-            command: Box::new(InsertChar(c)),
-        }
-    }
-}
-
 impl Command for InsertChar {
     fn call(&self, revi: &mut ReVi, _: usize) {
         revi.focused_window_mut().insert_char(self.0);
@@ -469,15 +301,7 @@ impl Command for InsertChar {
 }
 
 #[derive(Debug, PartialEq)]
-pub struct ChangeMode(Mode);
-impl ChangeMode {
-    pub fn new_box(mode: Mode) -> BoxedCommand {
-        BoxedCommand {
-            command: Box::new(ChangeMode(mode)),
-        }
-    }
-}
-
+pub struct ChangeMode(pub Mode);
 impl Command for ChangeMode {
     fn call(&self, revi: &mut ReVi, _: usize) {
         revi.change_modes(self.0);
@@ -490,14 +314,6 @@ impl Command for ChangeMode {
 
 #[derive(Debug, PartialEq)]
 pub struct EnterCommandMode;
-impl EnterCommandMode {
-    pub fn new_box() -> BoxedCommand {
-        BoxedCommand {
-            command: Box::new(EnterCommandMode),
-        }
-    }
-}
-
 impl Command for EnterCommandMode {
     fn call(&self, revi: &mut ReVi, _: usize) {
         revi.enter_command_mode();
@@ -510,14 +326,6 @@ impl Command for EnterCommandMode {
 
 #[derive(Debug, PartialEq)]
 pub struct ExitCommandMode;
-impl ExitCommandMode {
-    pub fn new_box() -> BoxedCommand {
-        BoxedCommand {
-            command: Box::new(ExitCommandMode),
-        }
-    }
-}
-
 impl Command for ExitCommandMode {
     fn call(&self, revi: &mut ReVi, _: usize) {
         if revi.focused == 0 {
@@ -532,14 +340,6 @@ impl Command for ExitCommandMode {
 
 #[derive(Debug, PartialEq)]
 pub struct ExcuteCommandLine;
-impl ExcuteCommandLine {
-    pub fn new_box() -> BoxedCommand {
-        BoxedCommand {
-            command: Box::new(ExcuteCommandLine),
-        }
-    }
-}
-
 impl Command for ExcuteCommandLine {
     fn call(&self, revi: &mut ReVi, _: usize) {
         if revi.focused == 0 {
@@ -553,14 +353,6 @@ impl Command for ExcuteCommandLine {
 
 #[derive(Debug, PartialEq)]
 pub struct NextWindow;
-impl NextWindow {
-    pub fn new_box() -> BoxedCommand {
-        BoxedCommand {
-            command: Box::new(NextWindow),
-        }
-    }
-}
-
 impl Command for NextWindow {
     fn call(&self, revi: &mut ReVi, _: usize) {
         revi.next_window();
@@ -573,14 +365,6 @@ impl Command for NextWindow {
 
 #[derive(Debug, PartialEq)]
 pub struct Print(String);
-impl Print {
-    pub fn new_box(string: &str) -> BoxedCommand {
-        BoxedCommand {
-            command: Box::new(Print(string.to_string())),
-        }
-    }
-}
-
 impl Command for Print {
     fn call(&self, revi: &mut ReVi, _: usize) {
         revi.print(&self.0);
@@ -593,14 +377,6 @@ impl Command for Print {
 
 #[derive(Debug, PartialEq)]
 pub struct Save;
-impl Save {
-    pub fn new_box() -> BoxedCommand {
-        BoxedCommand {
-            command: Box::new(Save),
-        }
-    }
-}
-
 impl Command for Save {
     fn call(&self, revi: &mut ReVi, _: usize) {
         revi.focused_window().save();
@@ -613,14 +389,6 @@ impl Command for Save {
 
 #[derive(Debug, PartialEq)]
 pub struct Quit;
-impl Quit {
-    pub fn new_box() -> BoxedCommand {
-        BoxedCommand {
-            command: Box::new(Quit),
-        }
-    }
-}
-
 impl Command for Quit {
     fn call(&self, revi: &mut ReVi, _: usize) {
         revi.exit();
@@ -632,14 +400,8 @@ impl Command for Quit {
 
 #[macro_export]
 macro_rules! commands {
-    ( $( $x:ident ),* ) => {
-        {
-            vec![$($x::new_box()),*]
-        }
-    };
-    ( $( $x:ident $($args:expr)*),* ) => {
-        {
-            vec![$($x::new_box($($args)*)),*]
-        }
-    };
+    ( $( $x:ident $(($($args:expr),*))? ),* ) => {
+            vec![$(BoxedCommand { command: Box::new($x $(($($args),*))?) }),*]
+    }
+
 }

--- a/crates/revi-core/src/key_parser.rs
+++ b/crates/revi-core/src/key_parser.rs
@@ -1,0 +1,121 @@
+// noun (adjective) verb
+// w    d
+// word delete
+//
+//    w
+//  -------
+// ↓       ↓
+// commands can be terminator type or extender
+//
+//
+// verb (adjective) noun
+// d     i          w
+#![allow(unused)]
+// use revi_core::commands::{
+//     Backspace, BoxedCommand, ChangeMode, Command, CursorDown, CursorLeft, CursorRight, CursorUp,
+//     DeleteChar, DeleteLine, End, EnterCommandMode, ExcuteCommandLine, ExitCommandMode,
+//     FirstCharInLine, Home, JumpToFirstLineBuffer, JumpToLastLineBuffer, MoveBackwardByWord,
+//     MoveForwardByWord, NewLine, NextWindow, Paste, PasteBack, Quit, Save, ScrollDown, ScrollUp,
+//     YankLine,
+// };
+// use revi_core::{Mapper, Mode};
+use revi_ui::{Key, Keys};
+
+// pub fn keys_parser<'a>(map: &'a Mapper, mode: Mode, keys: &[Key]) -> Option<&'a Vec<BoxedCommand>> {
+//     map.get_mapping(mode, keys)
+// }
+
+use std::{iter::Peekable, str::Chars};
+fn specal_keys<'a>(stream: &mut Peekable<Chars<'a>>) -> Vec<Key> {
+    let mut string = String::new();
+    while let Some(c) = stream.next_if(|c| c != &'>') {
+        string.push(c);
+    }
+    let _ = stream.next();
+    if string.contains("-") {
+        let lr = string.split("-").collect::<Vec<&str>>();
+        eprintln!("{:?}", lr);
+        let modifier = lr[0].to_lowercase();
+        let modifier = match modifier.as_str() {
+            "c" => "ctrl",
+            "a" => "alt",
+            m => m,
+        };
+        return vec![
+            Key::from(modifier),
+            Key::from(lr[1].chars().collect::<Vec<char>>()[0]),
+        ];
+    }
+    vec![Key::from(string.as_str())]
+}
+
+pub fn string_to_key(keys_string: &str) -> Vec<Key> {
+    let mut stream = keys_string.chars().peekable();
+    let mut keys = Vec::new();
+    while let Some(c) = stream.next() {
+        match c {
+            '<' => keys.append(&mut specal_keys(&mut stream)),
+            _ => keys.push(Key::from(c)),
+        }
+    }
+    keys
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn specal_keys_parser() {
+        let string = "esc>";
+        eprintln!("{:?}", string);
+        assert_eq!(vec![Key::Esc], specal_keys(&mut string.chars().peekable()));
+        let string = "space>";
+        eprintln!("{:?}", string);
+        assert_eq!(
+            vec![Key::Space],
+            specal_keys(&mut string.chars().peekable())
+        );
+        let string = "C-c>";
+        eprintln!("{:?}", string);
+        assert_eq!(
+            vec![Key::Ctrl, Key::LC],
+            specal_keys(&mut string.chars().peekable())
+        );
+    }
+
+    #[test]
+    fn parse_ctrl_a() {
+        let string = "<C-a>";
+        eprintln!("{:?}", string);
+        assert_eq!(vec![Key::Ctrl, Key::LA], string_to_key(string));
+    }
+
+    #[test]
+    fn parse_esc() {
+        let string = "<esc>";
+        eprintln!("{:?}", string);
+        assert_eq!(vec![Key::Esc], string_to_key(string));
+    }
+
+    #[test]
+    fn parse_ctrl_h() {
+        let string = "<C-h>";
+        eprintln!("{:?}", string);
+        assert_eq!(vec![Key::Ctrl, Key::LH], string_to_key(string));
+    }
+
+    #[test]
+    fn parse_i() {
+        let string = "i";
+        eprintln!("{:?}", string);
+        assert_eq!(vec![Key::LI], string_to_key(string));
+    }
+
+    #[test]
+    #[allow(non_snake_case)]
+    fn parse_I() {
+        let string = "I";
+        eprintln!("{:?}", string);
+        assert_eq!(vec![Key::UI], string_to_key(string));
+    }
+}

--- a/crates/revi-core/src/keymapper.rs
+++ b/crates/revi-core/src/keymapper.rs
@@ -5,8 +5,9 @@ use crate::commands::{
     JumpToFirstLineBuffer, JumpToLastLineBuffer, MoveBackwardByWord, MoveForwardByWord, NewLine,
     NextWindow, Paste, PasteBack, Quit, Save, ScrollDown, ScrollUp, YankLine,
 };
+use crate::key_parser::string_to_key;
 use crate::mode::Mode;
-use revi_ui::{keys, Key};
+use revi_ui::Key;
 use std::collections::HashMap;
 
 type KeyMap = HashMap<Vec<Key>, Vec<BoxedCommand>>;
@@ -54,135 +55,94 @@ impl Mapper {
         self.get_map(mode).get(event)
     }
     #[must_use]
-    pub fn with_mapping(mut self, mode: Mode, keys: Vec<Key>, commands: Vec<BoxedCommand>) -> Self {
-        self.get_map_mut(mode).insert(keys, commands);
+    pub fn with_mapping(mut self, mode: Mode, keys: &str, commands: Vec<BoxedCommand>) -> Self {
+        self.get_map_mut(mode).insert(string_to_key(keys), commands);
         self
     }
 
     fn build_normal(self) -> Self {
-        self.with_mapping(
-            Mode::Normal,
-            vec![Key::Esc],
-            commands![ChangeMode Mode::Normal],
-        )
-        .with_mapping(Mode::Normal, keys![LS, Ctrl], commands![Save])
-        .with_mapping(Mode::Normal, keys![UZ, UZ], commands![Save, Quit])
-        .with_mapping(Mode::Normal, keys![UZ, UQ], commands![Quit])
-        .with_mapping(Mode::Normal, keys![LJ], commands![CursorDown])
-        .with_mapping(Mode::Normal, keys![Down], commands![CursorDown])
-        .with_mapping(Mode::Normal, keys![LK], commands![CursorUp])
-        .with_mapping(Mode::Normal, keys![Up], commands![CursorUp])
-        .with_mapping(Mode::Normal, keys![LH], commands![CursorLeft])
-        .with_mapping(Mode::Normal, keys![Left], commands![CursorLeft])
-        .with_mapping(Mode::Normal, keys![LL], commands![CursorRight])
-        .with_mapping(Mode::Normal, keys![Right], commands![CursorRight])
-        .with_mapping(Mode::Normal, keys![Colon], commands![EnterCommandMode])
-        .with_mapping(Mode::Normal, keys![LI], commands![ChangeMode Mode::Insert])
-        .with_mapping(Mode::Normal, keys![LX], commands![DeleteChar])
-        .with_mapping(Mode::Normal, keys![Delete], commands![DeleteChar])
-        .with_mapping(
-            Mode::Normal,
-            vec![Key::LD, Key::LD],
-            commands![DeleteLine, CursorUp],
-        )
-        .with_mapping(Mode::Normal, keys![Home], commands![Home])
-        .with_mapping(Mode::Normal, keys![End], commands![End])
-        .with_mapping(Mode::Normal, keys![N0], commands![Home])
-        .with_mapping(Mode::Normal, keys![Char('$')], commands![End])
-        .with_mapping(
-            Mode::Normal,
-            keys![UA],
-            commands![
-                End,
-                ChangeMode Mode::Insert,
-                CursorRight
-            ],
-        )
-        .with_mapping(
-            Mode::Normal,
-            keys![LY, Ctrl],
-            commands![ScrollUp, CursorDown],
-        )
-        .with_mapping(
-            Mode::Normal,
-            keys![LE, Ctrl],
-            commands![ScrollDown, CursorUp],
-        )
-        .with_mapping(Mode::Normal, keys![LU, Ctrl], commands![ScrollUp])
-        .with_mapping(Mode::Normal, keys![LD, Ctrl], commands![ScrollDown])
-        .with_mapping(
-            Mode::Normal,
-            keys![LO],
-            commands![
-                End,
-                ChangeMode Mode::Insert,
-                CursorRight,
-                NewLine
-            ],
-        )
-        .with_mapping(
-            Mode::Normal,
-            keys![UO],
-            commands![
-                Home,
-                NewLine,
-                ChangeMode Mode::Insert,
-                CursorUp
-            ],
-        )
-        .with_mapping(Mode::Normal, keys![Caret], commands![FirstCharInLine])
-        .with_mapping(
-            Mode::Normal,
-            keys![UI],
-            commands![
-                FirstCharInLine,
-                ChangeMode Mode::Insert
-            ],
-        )
-        .with_mapping(Mode::Normal, keys![LW], commands![MoveForwardByWord])
-        .with_mapping(Mode::Normal, keys![LB], commands![MoveBackwardByWord])
-        .with_mapping(
-            Mode::Normal,
-            keys![LG, LG],
-            commands![JumpToFirstLineBuffer],
-        )
-        .with_mapping(Mode::Normal, keys![UG], commands![JumpToLastLineBuffer])
-        .with_mapping(
-            Mode::Normal,
-            keys![LW, Ctrl, LW, Ctrl],
-            commands![NextWindow],
-        )
-        .with_mapping(
-            Mode::Normal,
-            keys![Enter],
-            commands![ExcuteCommandLine, ExitCommandMode],
-        )
-        .with_mapping(Mode::Normal, keys![LY, LY], commands![YankLine])
-        .with_mapping(Mode::Normal, keys![LP], commands![Paste])
-        .with_mapping(Mode::Normal, keys![UP], commands![PasteBack])
+        self.with_mapping(Mode::Normal, "<esc>", commands![ChangeMode(Mode::Normal)])
+            .with_mapping(Mode::Normal, "<C-s>", commands![Save])
+            .with_mapping(Mode::Normal, "zz", commands![Save, Quit])
+            .with_mapping(Mode::Normal, "zq", commands![Quit])
+            .with_mapping(Mode::Normal, "j", commands![CursorDown])
+            .with_mapping(Mode::Normal, "down", commands![CursorDown])
+            .with_mapping(Mode::Normal, "k", commands![CursorUp])
+            .with_mapping(Mode::Normal, "up", commands![CursorUp])
+            .with_mapping(Mode::Normal, "h", commands![CursorLeft])
+            .with_mapping(Mode::Normal, "left", commands![CursorLeft])
+            .with_mapping(Mode::Normal, "l", commands![CursorRight])
+            .with_mapping(Mode::Normal, "right", commands![CursorRight])
+            .with_mapping(Mode::Normal, ":", commands![EnterCommandMode])
+            .with_mapping(Mode::Normal, "i", commands![ChangeMode(Mode::Insert)])
+            .with_mapping(Mode::Normal, "x", commands![DeleteChar])
+            .with_mapping(Mode::Normal, "delete", commands![DeleteChar])
+            .with_mapping(Mode::Normal, "dd", commands![DeleteLine, CursorUp])
+            .with_mapping(Mode::Normal, "home", commands![Home])
+            .with_mapping(Mode::Normal, "end", commands![End])
+            .with_mapping(Mode::Normal, "0", commands![Home])
+            .with_mapping(Mode::Normal, "$", commands![End])
+            .with_mapping(
+                Mode::Normal,
+                "A",
+                commands![End, ChangeMode(Mode::Insert), CursorRight],
+            )
+            .with_mapping(Mode::Normal, "<C-y>", commands![ScrollUp, CursorDown])
+            .with_mapping(Mode::Normal, "<C-e>", commands![ScrollDown, CursorUp])
+            .with_mapping(Mode::Normal, "<C-u>", commands![ScrollUp])
+            .with_mapping(Mode::Normal, "<C-d>", commands![ScrollDown])
+            .with_mapping(
+                Mode::Normal,
+                "o",
+                commands![End, ChangeMode(Mode::Insert), CursorRight, NewLine],
+            )
+            .with_mapping(
+                Mode::Normal,
+                "O",
+                commands![Home, NewLine, ChangeMode(Mode::Insert), CursorUp],
+            )
+            .with_mapping(Mode::Normal, "^", commands![FirstCharInLine])
+            .with_mapping(
+                Mode::Normal,
+                "I",
+                commands![FirstCharInLine, ChangeMode(Mode::Insert)],
+            )
+            .with_mapping(Mode::Normal, "w", commands![MoveForwardByWord])
+            .with_mapping(Mode::Normal, "b", commands![MoveBackwardByWord])
+            .with_mapping(Mode::Normal, "gg", commands![JumpToFirstLineBuffer])
+            .with_mapping(Mode::Normal, "G", commands![JumpToLastLineBuffer])
+            .with_mapping(Mode::Normal, "<C-w><C-w>", commands![NextWindow])
+            .with_mapping(
+                Mode::Normal,
+                "<enter>",
+                commands![ExcuteCommandLine, ExitCommandMode],
+            )
+            .with_mapping(Mode::Normal, "yy", commands![YankLine])
+            .with_mapping(Mode::Normal, "p", commands![Paste])
+            .with_mapping(Mode::Normal, "P", commands![PasteBack])
     }
 
     fn build_insert(self) -> Self {
-        self.with_mapping(Mode::Insert, keys![Esc], commands![ChangeMode Mode::Normal])
-            .with_mapping(Mode::Insert, keys![Backspace], commands![Backspace])
+        self.with_mapping(Mode::Insert, "<esc>", commands![ChangeMode(Mode::Normal)])
+            .with_mapping(Mode::Insert, "<backspace>", commands![Backspace])
             .with_mapping(
                 Mode::Insert,
-                keys![Enter],
+                "<enter>",
                 commands![NewLine, ExcuteCommandLine, ExitCommandMode],
             )
-            .with_mapping(Mode::Insert, keys![Home], commands![Home])
-            .with_mapping(Mode::Insert, keys![End], commands![End])
-            .with_mapping(Mode::Insert, keys![Down], commands![CursorDown])
-            .with_mapping(Mode::Insert, keys![Up], commands![CursorUp])
-            .with_mapping(Mode::Insert, keys![Left], commands![CursorLeft])
-            .with_mapping(Mode::Insert, keys![Right], commands![CursorRight])
+            .with_mapping(Mode::Insert, "<home>", commands![Home])
+            .with_mapping(Mode::Insert, "<end>", commands![End])
+            .with_mapping(Mode::Insert, "<down>", commands![CursorDown])
+            .with_mapping(Mode::Insert, "<up>", commands![CursorUp])
+            .with_mapping(Mode::Insert, "<left>", commands![CursorLeft])
+            .with_mapping(Mode::Insert, "<right>", commands![CursorRight])
     }
 
     fn build_command(self) -> Self {
-        self.with_mapping(Mode::Command, keys![Esc], commands![ExitCommandMode])
+        self.with_mapping(Mode::Command, "<esc>", commands![ExitCommandMode])
             .with_mapping(
                 Mode::Command,
-                keys![Enter],
+                "enter",
                 commands![ExcuteCommandLine, ExitCommandMode],
             )
     }

--- a/crates/revi-core/src/lib.rs
+++ b/crates/revi-core/src/lib.rs
@@ -7,6 +7,7 @@
 mod api;
 pub mod buffer;
 pub mod commands;
+mod key_parser;
 pub mod line_number;
 pub mod mode;
 pub mod position;

--- a/crates/revi-ui/src/key.rs
+++ b/crates/revi-ui/src/key.rs
@@ -135,6 +135,43 @@ impl From<u8> for Key {
         }
     }
 }
+impl From<&str> for Key {
+    fn from(c: &str) -> Self {
+        match c.to_lowercase().as_str() {
+            "ctrl" => Key::Ctrl,
+            "alt" => Key::Alt,
+            "space" => Key::Space,
+            "esc" => Key::Esc,
+            "enter" => Key::Enter,
+            "backspace" => Key::Backspace,
+            "left" => Key::Left,
+            "right" => Key::Right,
+            "up" => Key::Up,
+            "down" => Key::Down,
+            "home" => Key::Home,
+            "end" => Key::End,
+            "pageup" => Key::PageUp,
+            "pagedown" => Key::PageDown,
+            "tab" => Key::Tab,
+            "backtab" => Key::BackTab,
+            "delete" => Key::Delete,
+            "insert" => Key::Insert,
+            "f1" => Self::from(1),
+            "f2" => Self::from(2),
+            "f3" => Self::from(3),
+            "f4" => Self::from(4),
+            "f5" => Self::from(5),
+            "f6" => Self::from(6),
+            "f7" => Self::from(7),
+            "f8" => Self::from(8),
+            "f9" => Self::from(9),
+            "f10" => Self::from(10),
+            "f11" => Self::from(11),
+            "f12" => Self::from(12),
+            _ => Key::Null,
+        }
+    }
+}
 impl From<char> for Key {
     fn from(c: char) -> Self {
         match c {

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,6 @@ use revi_core::{commands::*, Mapper, Mode, ReVi};
 use revi_ui::{Key, Tui};
 
 use mlua::prelude::*;
-// use ropey::Rope;
 
 #[allow(dead_code)]
 fn main() -> LuaResult<()> {
@@ -48,7 +47,9 @@ fn main() -> LuaResult<()> {
                     .as_chars()
                     .iter()
                     .filter(|c| **c != '\0')
-                    .map(|c| InsertChar::new_box(*c))
+                    .map(|c| BoxedCommand {
+                        command: Box::new(InsertChar(*c)),
+                    })
                     .collect::<Vec<BoxedCommand>>();
                 revi.borrow_mut()
                     .execute(input.number_usize(), &input_chars);


### PR DESCRIPTION
Also condensed the command macro to apply `BoxedCommand` struct instead of calling custom constructor method that had the same signature on every type.